### PR TITLE
Fix changelog link in docs

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -9,6 +9,7 @@
 <!-- Please write your name alphabetically. -->
 
 - C.A.M. Gerlach (@CAM-Gerlach) <CAM.Gerlach@Gerlach.CAM>
+- Drew Winstel (@drewbrew) <drew@hsv.beer>
 - Furkan Önder (@furkanonder) <furkanonder@protonmail.com>
 - Hadi Alqattan (@hadialqattan) <alqattanhadizaki@gmail.com>
 - Işık Kaplan (@isik-kaplan) <isik.kaplan@outlook.com>

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@
 
 - **Documentation** https://unimport.hakancelik.dev/
 - **Issues** https://github.com/hakancelikdev/unimport/issues/
-- **Changelog** https://unimport.hakancelik.dev/changelog
+- **Changelog** https://unimport.hakancelik.dev/CHANGELOG/
 - **Playground** https://playground-unimport.hakancelik.dev/
 
 Unimport is a linter and formatter for finding and removing unused import statements.


### PR DESCRIPTION
Just a quick case-sensitivity issue: `/changelog` returns a 404, while `/CHANGELOG/` returns the right page.

It looks like this got missed in #250. I didn't think it was worthy of a CHANGELOG entry since there's no code fix required.

<!--
## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the
[Contributing Guidelines](https://github.com/hakancelikdev/unimport/blob/main/docs/CONTRIBUTING.md).
-->
