### PR TITLE
Don't color diffs when `--color=never` is used

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -8,6 +8,7 @@
 
 <!-- Please write your name alphabetically. -->
 
+- Benjamin Schubert (@BenjaminSchubert) <contact@benschubert.me>
 - C.A.M. Gerlach (@CAM-Gerlach) <CAM.Gerlach@Gerlach.CAM>
 - Drew Winstel (@drewbrew) <drew@hsv.beer>
 - Furkan Önder (@furkanonder) <furkanonder@protonmail.com>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Fixes
 
-- `--color=never` is now respected hwen showing the diffs
+- `--color=never` is now respected when showing the diffs
 
 ## 0.12.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - ././
+
+### 🐛 Fixes
+
+- `--color=never` is now respected hwen showing the diffs
+
 ## 0.12.1
 
 ### 🐛 Fixes

--- a/src/unimport/color.py
+++ b/src/unimport/color.py
@@ -67,15 +67,15 @@ def paint(text: str, color: Color, use_color: bool = True) -> str:
     return color.value + text + Color.RESET.value if use_color else text
 
 
-def difference(text: Tuple[str, ...]) -> str:  # pragma: no cover
+def difference(text: Tuple[str, ...], use_color: bool = True) -> str:  # pragma: no cover
     lines = list(text)
     for i, line in enumerate(lines):
         if line.startswith("+++") or line.startswith("---"):
-            lines[i] = paint(line, Color.BOLD_WHITE)
+            lines[i] = paint(line, Color.BOLD_WHITE, use_color)
         elif line.startswith("@@"):
-            lines[i] = paint(line, Color.CYAN)
+            lines[i] = paint(line, Color.CYAN, use_color)
         elif line.startswith("+"):
-            lines[i] = paint(line, Color.GREEN)
+            lines[i] = paint(line, Color.GREEN, use_color)
         elif line.startswith("-"):
-            lines[i] = paint(line, Color.RED)
+            lines[i] = paint(line, Color.RED, use_color)
     return "\n".join(lines)

--- a/src/unimport/commands/diff.py
+++ b/src/unimport/commands/diff.py
@@ -6,10 +6,10 @@ from unimport.color import difference
 __all__ = ("diff",)
 
 
-def diff(path: Path, source: str, refactor_result: str) -> bool:
+def diff(path: Path, source: str, refactor_result: str, use_color: bool = True) -> bool:
     diff_ = utils.diff(source=source, refactor_result=refactor_result, fromfile=path)
     exists_diff = bool(diff_)
     if exists_diff:
-        print(difference(diff_))
+        print(difference(diff_, use_color))
 
     return exists_diff

--- a/src/unimport/main.py
+++ b/src/unimport/main.py
@@ -93,9 +93,8 @@ class Main:
         )
         self.refactor_applied = True
 
-    @staticmethod
-    def diff(result, refactor_result):
-        return commands.diff(result.path, result.source, refactor_result)
+    def diff(self, result, refactor_result):
+        return commands.diff(result.path, result.source, refactor_result, self.config.use_color)
 
     def permission(self, result, refactor_result):
         commands.permission(

--- a/tests/commands/test_diff.py
+++ b/tests/commands/test_diff.py
@@ -3,31 +3,58 @@ import textwrap
 from contextlib import redirect_stdout
 from pathlib import Path
 
+import pytest
+
 from unimport.commands import diff
 
 
-def test_diff_not_exits_diff():
+@pytest.mark.parametrize("use_color", [True, False])
+def test_diff_not_exits_diff(use_color):
     with redirect_stdout(io.StringIO()) as f:
-        exists_diff = diff(Path("example.py"), "source", "source")
+        exists_diff = diff(Path("example.py"), "source", "source", use_color)
 
     assert f.getvalue() == ""
     assert exists_diff is False
 
 
-def test_diff_exits_diff():
-    with redirect_stdout(io.StringIO()) as f:
-        exists_diff = diff(Path("example.py"), "source", "refactor_result")
+@pytest.mark.parametrize(
+    ("use_color", "stdout"),
+    [
+        [
+            True,
+            textwrap.dedent(
+                """\
+                \x1b[1;37m--- example.py
+                \x1b[0m
+                \x1b[1;37m+++ 
+                \x1b[0m
+                \x1b[36m@@ -1 +1 @@
+                \x1b[0m
+                \x1b[31m-source\x1b[0m
+                \x1b[32m+refactor_result\x1b[0m
+                """
+            ),
+        ],
+        [
+            False,
+            textwrap.dedent(
+                """\
+                --- example.py
 
-    assert f.getvalue() == textwrap.dedent(
-        """\
-        \x1b[1;37m--- example.py
-        \x1b[0m
-        \x1b[1;37m+++ 
-        \x1b[0m
-        \x1b[36m@@ -1 +1 @@
-        \x1b[0m
-        \x1b[31m-source\x1b[0m
-        \x1b[32m+refactor_result\x1b[0m
-        """
-    )
+                +++ 
+
+                @@ -1 +1 @@
+
+                -source
+                +refactor_result
+                """
+            ),
+        ],
+    ],
+)
+def test_diff_exits_diff(use_color, stdout):
+    with redirect_stdout(io.StringIO()) as f:
+        exists_diff = diff(Path("example.py"), "source", "refactor_result", use_color)
+
+    assert f.getvalue() == stdout
     assert exists_diff is True


### PR DESCRIPTION
Previously, colors would be shown all the time, even when `--color=never` was passed

fix #265 

Hey! I think I followed the contributing guide correctly, if I forgot something, please let me know.