### PR TITLE
Add `--remove` arg to `.pre-commit-hooks.yaml`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,4 @@
   language: python
   language_version: python3
   types: [python]
+  args: ["--remove"]


### PR DESCRIPTION
Hello, thanks for the great tool!

Would you consider changing the `pre-commit` config to automatically remove unused imports? See the attached patch. The motivation for this change is

- **User experience**: Currently, users need to read the error and rerun unimport to remove the duplicate imports or manually remove them. With this change, `pre-commit` can remove them automatically
- **Consistency with other fixers**: Many fixers take advantage of this property. For example, [black](https://github.com/psf/black), [reorder_python_imports](https://github.com/asottile/reorder_python_imports), [pyupgrade](https://github.com/asottile/pyupgrade), [unkey](https://github.com/mxr/unkey), and so on simply fix user's code. Running `unimport` in `pre-commit` in this way will make `unimport` simply fix user's code, too.
- **Consistency with user expectations**: Many users of `pre-commit` use the `--show-diff-on-failure` argument ([link](https://sourcegraph.com/search?q=context:global+show-diff-on-failure+file:tox.ini&patternType=standard&sm=1)). If `unimport` makes a change when the fixer runs, the diff of the change will be shown to the user too
- **Maintains safety**: If unused imports are found, `pre-commit` will still block the commit so users have a chance to review the change (in case `unimport` has a bug). This is a design decision by `pre-commit` which will not change. 

I verified the change as follows:

1) Pointed a repo to the updated config
	```yaml
	-   repo: https://github.com/mxr/unimport
	    rev: d0af8af1aed8ec49723dcc52ea4896af0beb531f
	    hooks:
	    -   id: unimport
	```
2) Set up a file with double imports
	```console
	$ head day05.py                                                  
	from __future__ import annotations
	import functools
	import re
	import re
	from itertools import zip_longest
	
	RE = re.compile(r"\d+")
	SKIP = frozenset(("[", "]", " "))


	```
3) Ran the hook and verified it worked
	```console
	$ pre-commit run unimport --files day05.py        
	unimport.................................................................Failed
	- hook id: unimport
	- files were modified by this hook
	
	Refactoring 'day05.py'
	
	$ head day05.py                                                  
	from __future__ import annotations
	import functools
	import re
	from itertools import zip_longest
	
	RE = re.compile(r"\d+")
	SKIP = frozenset(("[", "]", " "))
	
	
	def parse(filename: str) -> str:
	```
4) Alternatively, ran the hook and output the diff at the same time
	```console
	$ pre-commit run --show-diff-on-failure unimport --files day05.py
	unimport.................................................................Failed
	- hook id: unimport
	- files were modified by this hook
	
	Refactoring 'day05.py'
	
	All changes made by hooks:
	diff --git a/day05.py b/day05.py
	index 4808afe..e928078 100644
	--- a/day05.py
	+++ b/day05.py
	@@ -1,7 +1,6 @@
	 from __future__ import annotations
	 import functools
	 import re
	-import re
	 from itertools import zip_longest
	 
	 RE = re.compile(r"\d+")
	```