### PR TITLE
Add: Support for Python version 3.11.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3.5.3
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/hakancelikdev/unimport
-    rev: 1.0.1
+    rev: 1.1.0
     hooks:
       - id: unimport
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.11-alpine
 
 COPY . /app
 WORKDIR /app

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: pip install --upgrade pip && python -m pip install unimport==1.0.1
+    - run: pip install --upgrade pip && python -m pip install unimport==1.1.0
       shell: bash
     - run: unimport --color auto --gitignore --ignore-init ${{ inputs.extra_args }}
       shell: bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - YYYY-MM-DD
 
+## [1.1.0] - 2023-11-17
+
+### Added
+
+- Support for Python version 3.11.
+
 ## [1.0.1] - 2023-11-17
 
 ### Changed

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,13 +35,15 @@ $ git rebase upstream/main
 
 ## Testing
 
-Firstly make sure you have py3.6, py3.7, py3.8, py3.9 and py3.10 python versions
-installed on your system.
+First, make sure you have at least one of the python versions py3.6, py3.7, py3.8,
+py3.9, py3.10 and py3.11. If not all versions are available, after opening PR, github
+action will run the tests for each version, so you can be sure that you wrote the
+correct code. You can skip the tox step below.
 
 After typing your codes, you should run the tests by typing the following command.
 
 ```shell
-$ python3.10 -m pip install tox
+$ python3.11 -m pip install tox
 $ tox
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,5 +29,5 @@ process with Unimport.
 
 - **Documentation** https://unimport.hakancelik.dev/
 - **Issues** https://github.com/hakancelikdev/unimport/issues/
-- **Changelog** https://unimport.hakancelik.dev/1.0.1/CHANGELOG/
+- **Changelog** https://unimport.hakancelik.dev/1.1.0/CHANGELOG/
 - **Playground** https://playground-unimport.hakancelik.dev/

--- a/docs/tutorial/use-with-github-action.md
+++ b/docs/tutorial/use-with-github-action.md
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3.5.3
       - uses: actions/setup-python@v4.6.1
       - name: Check unused imports
-        uses: hakancelikdev/unimport@1.0.1
+        uses: hakancelikdev/unimport@1.1.0
         with:
           extra_args: --include src/
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,8 +75,6 @@ extra:
       searching for. With your consent, you're helping us to make our documentation
       better.
   social:
-    - icon: fontawesome/brands/discord
-      link: https://discord.com/invite/6z8YXy4
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/hakancelikdev
     - icon: fontawesome/brands/linkedin

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 project_urls =
     Documentation = https://unimport.hakancelik.dev/
     Issues = https://github.com/hakancelikdev/unimport/issues/
-    Changelog = https://unimport.hakancelik.dev/1.0.1/CHANGELOG/
+    Changelog = https://unimport.hakancelik.dev/1.1.0/CHANGELOG/
 
 [options]
 python_requires = >=3.6, <3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Environment :: Console
     Topic :: Software Development :: Libraries :: Python Modules
@@ -32,7 +33,7 @@ project_urls =
     Changelog = https://unimport.hakancelik.dev/1.0.1/CHANGELOG/
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.6, <3.12
 include_package_data = true
 zip_safe = true
 packages =
@@ -42,12 +43,16 @@ packages =
 package_dir =
     =src
 install_requires =
-    libcst>=0.3.7, <1; python_version >= '3.9'
-    libcst>=0.3.0, <1; python_version <= '3.8'
+    libcst>=0.4.10, <=1.1.0; python_version >= '3.11'
+    libcst>=0.3.7, <=1.1.0; python_version == '3.10'
+    libcst>=0.3.7, <=1.1.0; python_version == '3.9'
+    libcst>=0.3.0, <=1.1.0; python_version == '3.8'
+    libcst>=0.3.0, <=1.0.1; python_version == '3.7'
+    libcst>=0.3.0, <=0.4.1; python_version == '3.6'
     pathspec>=0.10.1, <1; python_version >= '3.7'
-    pathspec>=0.5.0, <0.10.0; python_version == '3.6'
+    pathspec>=0.5.0, <=0.9.0; python_version == '3.6'
     toml>=0.9.0, <1
-    dataclasses>=0.5, <1; python_version < '3.7'
+    dataclasses>=0.5, <1; python_version == '3.6'
     typing-extensions>=3.7.4, <4; python_version < '3.8'
 
 [options.entry_points]
@@ -56,15 +61,15 @@ console_scripts =
 
 [options.extras_require]
 docs =
-    mkdocs==1.4.3
-    mkdocs-material==9.1.18
+    mkdocs==1.5.3
+    mkdocs-material==9.4.9
     mkdocs-markdownextradata-plugin==0.2.5
-    mkdocs-minify-plugin==0.6.4
-    mkdocs-git-revision-date-localized-plugin==1.2.0
-    mike==1.1.2
+    mkdocs-minify-plugin==0.7.1
+    mkdocs-git-revision-date-localized-plugin==1.2.1
+    mike==2.0.0
 test =
     pytest==6.2.4; python_version == '3.6'
-    pytest==7.4.0; python_version != '3.6'
+    pytest==7.4.3; python_version != '3.6'
     pytest-cov==4.0.0; python_version == '3.6'
     pytest-cov==4.1.0; python_version != '3.6'
     semantic-version==2.10.0

--- a/src/unimport/__init__.py
+++ b/src/unimport/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 __description__ = "A linter, formatter for finding and removing unused import statements."

--- a/tests/cases/analyzer/statement/match_statement.py
+++ b/tests/cases/analyzer/statement/match_statement.py
@@ -1,0 +1,17 @@
+from typing import List, Union
+
+from unimport.statement import Import, ImportFrom, Name
+
+__all__ = ["NAMES", "IMPORTS", "UNUSED_IMPORTS"]
+
+
+NAMES: List[Name] = [
+    Name(lineno=3, name='sort_by', is_all=False),
+    Name(lineno=4, name='sort_by', is_all=False),
+    Name(lineno=5, name='sort_by', is_all=False),
+]
+IMPORTS: List[Union[Import, ImportFrom]] = [
+]
+UNUSED_IMPORTS: List[Union[Import, ImportFrom]] = [
+
+]

--- a/tests/cases/refactor/statement/match_statement.py
+++ b/tests/cases/refactor/statement/match_statement.py
@@ -1,0 +1,5 @@
+# https://github.com/hakancelikdev/unimport/issues/291
+
+match sort_by:
+    case 'date': sort_by = ' updated DESC,'
+    case _:      sort_by = ''

--- a/tests/cases/source/statement/match_statement.py
+++ b/tests/cases/source/statement/match_statement.py
@@ -1,0 +1,5 @@
+# https://github.com/hakancelikdev/unimport/issues/291
+
+match sort_by:
+    case 'date': sort_by = ' updated DESC,'
+    case _:      sort_by = ''

--- a/tests/cases/test_cases.py
+++ b/tests/cases/test_cases.py
@@ -34,7 +34,7 @@ def test_cases(path: Path, logger):
     skip = re.search("# skip; condition: (?P<condition>.*), reason: (?P<reason>.*)", source, re.IGNORECASE)
     if skip:
         condition = skip.group("condition")
-        if condition in ["not PY38_PLUS"] and eval(condition):
+        if condition in ("not PY38_PLUS",) and eval(condition):
             reason = skip.group("reason")
             pytest.skip(reason, allow_module_level=True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 3.6, 3.7, 3.8, 3.9, 3.10, pre-commit
+envlist = 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, pre-commit
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
- I tested Codebase in large projects
- I checked the changes coming with Python 3.11
- I checked the available packages
- I have made changes indicating that it is suitable for the versions we officially support, unimport cannot be used with python version 3.12.