### PR TITLE
Fix false positive when import and usage are on the same line (#292)

### DIFF
--- a/src/unimport/statement.py
+++ b/src/unimport/statement.py
@@ -167,9 +167,9 @@ class Name:
             sub_match = (
                 not primary_match and imp.is_match_sub_packages(self.name) and not self._has_more_specific_import(imp)
             )
-            is_match = (imp.lineno < self.lineno or self._is_deferred_usage(imp)) and (primary_match or sub_match)
+            is_match = (imp.lineno <= self.lineno or self._is_deferred_usage(imp)) and (primary_match or sub_match)
         else:
-            is_match = (imp.lineno < self.lineno or self._is_deferred_usage(imp)) and (
+            is_match = (imp.lineno <= self.lineno or self._is_deferred_usage(imp)) and (
                 self.name == imp.name or imp.is_match_sub_packages(self.name)
             )
 

--- a/tests/cases/analyzer/statement/semicolon_same_line.py
+++ b/tests/cases/analyzer/statement/semicolon_same_line.py
@@ -1,0 +1,21 @@
+from typing import Union
+
+from unimport.statement import Import, ImportFrom, Name
+
+__all__ = ["NAMES", "IMPORTS", "UNUSED_IMPORTS"]
+
+
+NAMES: list[Name] = [
+    Name(lineno=1, name="print", is_all=False),
+    Name(lineno=1, name="pathlib.Path", is_all=False),
+    Name(lineno=1, name="__file__", is_all=False),
+    Name(lineno=2, name="sys.exit", is_all=False),
+    Name(lineno=2, name="doctest.testmod", is_all=False),
+    Name(lineno=2, name="doctest.ELLIPSIS", is_all=False),
+]
+IMPORTS: list[Union[Import, ImportFrom]] = [
+    Import(lineno=1, column=1, name="pathlib", package="pathlib"),
+    Import(lineno=2, column=1, name="doctest", package="doctest"),
+    Import(lineno=2, column=2, name="sys", package="sys"),
+]
+UNUSED_IMPORTS: list[Union[Import, ImportFrom]] = []

--- a/tests/cases/refactor/statement/semicolon_same_line.py
+++ b/tests/cases/refactor/statement/semicolon_same_line.py
@@ -1,0 +1,2 @@
+if True: import pathlib; print(pathlib.Path(__file__))
+if True: import doctest, sys; sys.exit(doctest.testmod(optionflags=doctest.ELLIPSIS)[0])

--- a/tests/cases/source/statement/semicolon_same_line.py
+++ b/tests/cases/source/statement/semicolon_same_line.py
@@ -1,0 +1,2 @@
+if True: import pathlib; print(pathlib.Path(__file__))
+if True: import doctest, sys; sys.exit(doctest.testmod(optionflags=doctest.ELLIPSIS)[0])


### PR DESCRIPTION
Change strict less-than to less-than-or-equal in Name.match_2 lineno comparison so that semicolon-separated import+usage on the same line is correctly recognized as used.

<!--
## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the
[Contributing Guidelines](https://github.com/hakancelikdev/unimport/blob/main/docs/CONTRIBUTING.md).
-->
